### PR TITLE
external rewards admin

### DIFF
--- a/packages/contracts/contracts/interfaces/IExternalRewardsDistributor.sol
+++ b/packages/contracts/contracts/interfaces/IExternalRewardsDistributor.sol
@@ -24,6 +24,8 @@ interface IExternalRewardsDistributor {
 
     event HarvestedReward(address indexed stakingContract);
 
+    event RewardAdminChanged(address rewardAdmin);
+
     enum StakingType {
         NOT_SET, // unset value of 0 can be used to delineate which staking contracts have been set
         YEARN_OP,

--- a/packages/contracts/contracts/protocol/incentives/ExternalRewardDistributor.sol
+++ b/packages/contracts/contracts/protocol/incentives/ExternalRewardDistributor.sol
@@ -30,6 +30,8 @@ contract ExternalRewardDistributor is IExternalRewardsDistributor, Initializable
   bytes32 public currRoot; // The merkle tree's root of the current rewards distribution.
   mapping(address => mapping(address => uint256)) public claimed; // The rewards already claimed. account -> amount.
 
+  address public rewardAdmin;
+
   uint256[40] __gap_ExternalRewardDistributor;
 
   modifier onlyGlobalAdmin() {
@@ -42,11 +44,22 @@ contract ExternalRewardDistributor is IExternalRewardsDistributor, Initializable
       _;
   }
 
+  modifier onlyRewardAdmin() {
+    require(msg.sender == rewardAdmin, "Only reward admin");
+    _;
+  }
+
   function __ExternalRewardDistributor_init(address _addressesProvider) internal onlyInitializing {
     addressesProvider = ILendingPoolAddressesProvider(_addressesProvider);
   }
 
   /******** External functions ********/
+
+  function setRewardAdmin(address newRewardAdmin) external onlyGlobalAdmin {
+    rewardAdmin = newRewardAdmin;
+
+    emit RewardAdminChanged(newRewardAdmin);
+  }
 
   function batchBeginStakingRewards(
       address[] calldata aTokens,
@@ -125,7 +138,7 @@ contract ExternalRewardDistributor is IExternalRewardsDistributor, Initializable
 
   /// @notice Updates the current merkle tree's root.
   /// @param _newRoot The new merkle tree's root.
-  function updateRoot(bytes32 _newRoot) external onlyGlobalAdmin {
+  function updateRoot(bytes32 _newRoot) external onlyRewardAdmin {
       currRoot = _newRoot;
       emit RootUpdated(_newRoot);
   }

--- a/packages/contracts/test-suites/test-aave/incentives/external/configure.spec.ts
+++ b/packages/contracts/test-suites/test-aave/incentives/external/configure.spec.ts
@@ -195,6 +195,12 @@ makeSuite('ExternalRewardsDistributor configure rewards', (testEnv: TestEnv) => 
     assetData = await incentivesController.getStakingContract(aToken.address);
     expect(assetData).equal(stakingContracts[6].address)
   })
+
+  it('setRewardAdmin', async () => {
+    const { incentivesController, deployer } = testEnv;
+    await incentivesController.setRewardAdmin(deployer.address)
+  })
+
   it('Calculate Merkle and claim rewards', async () => {
     const { incentivesController, incentivizedTokens, usdc, stakingContracts, incentUnderlying, users, rewardTokens, dai, leafNodes } = testEnv;
     const arr = leafNodes.map((i,ix) => {


### PR DESCRIPTION
updateRoot on ExternalRewardDistributor.sol can only be called by reward admin - new role that can be set by global admin, and is used every day to update the merkle root of reward tokens