### PR TITLE
curve claim from gauge factory

### DIFF
--- a/packages/contracts/contracts/interfaces/ICurveGaugeFactory.sol
+++ b/packages/contracts/contracts/interfaces/ICurveGaugeFactory.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.19;
+
+interface ICurveGaugeFactory {
+    function mint(address gauge) external;
+}

--- a/packages/contracts/contracts/interfaces/IExternalRewardsDistributor.sol
+++ b/packages/contracts/contracts/interfaces/IExternalRewardsDistributor.sol
@@ -28,6 +28,8 @@ interface IExternalRewardsDistributor {
 
     event StakingTypeSet(address indexed stakingContract, uint8 stakingType);
 
+    event CurveGaugeFactorySet(address curveGaugeFactory);
+
     enum StakingType {
         NOT_SET, // unset value of 0 can be used to delineate which staking contracts have been set
         YEARN_OP,


### PR DESCRIPTION
Curve gauges have rewards(OP tokens) which are expired. They also have CRV rewards which are still active.
They are not claimed via:
`        ICurveRewardGauge(stakingContract).claim_rewards();
`

but via:
`          ICurveGaugeFactory(curveGaugeFactoryAddress).mint(stakingContract);
`

I tested it out from curve UI and it worked. So we should upgrade our IncentivesController contract to have the ability to claim from curve gauge factory as well