### PR TITLE
hotfix: TrancheNameChanged event remove indexing name

### DIFF
--- a/packages/contracts/contracts/interfaces/ILendingPoolConfigurator.sol
+++ b/packages/contracts/contracts/interfaces/ILendingPoolConfigurator.sol
@@ -17,7 +17,7 @@ interface ILendingPoolConfigurator {
     }
 
     struct ConfigureCollateralParamsInput {
-        address underlyingAsset; 
+        address underlyingAsset;
         ConfigureCollateralParams collateralParams;
     }
 
@@ -36,7 +36,7 @@ interface ILendingPoolConfigurator {
      * @param factor The new reserve factor
      **/
     event ReserveFactorChanged(address indexed asset, uint64 indexed trancheId, uint256 factor);
-    event TrancheNameChanged(uint64 indexed trancheId, string indexed name);
+    event TrancheNameChanged(uint64 indexed trancheId, string name);
     event AddedWhitelistedDepositBorrow(address indexed user);
 
     event UpdatedTreasuryAddress(uint64 trancheId, address newAddress);


### PR DESCRIPTION
Issue: when changing tranche name, we can not decode the new tranche name since it is indexed
https://ethereum.stackexchange.com/questions/6840/indexed-event-with-string-not-getting-logged

After this merges, we need to
1) deploy changes on all chains (or we can wait for more changes to go in before deploying)
2) bump up minor version of contracts and deploy to npm
3) change fe version

see: https://www.notion.so/vmex/Deployment-guidelines-c326cfe161ae46aa97614ea0ece1dd2c?pvs=4 (internal document)